### PR TITLE
Push docker image to artifact registry

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,10 +12,10 @@ jobs:
   deploy-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Login to GCR
+      - name: Login to Artifact Registry/GCR
         uses: docker/login-action@v2
         with:
-          registry: gcr.io
+          registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
 
@@ -25,4 +25,4 @@ jobs:
       #   continue-on-error: true
       - name: Build & Publish the Docker image
         run: |
-          docker buildx create --name builder --use --platform=linux/amd64,linux/arm64  && docker buildx build --file ./Dockerfile-evm --platform=linux/amd64,linux/arm64 . -t gcr.io/covalent-project/evm-server:latest --push
+          docker buildx create --name builder --use --platform=linux/amd64,linux/arm64  && docker buildx build --file ./Dockerfile-evm --platform=linux/amd64,linux/arm64 . -t us-docker.pkg.dev/covalent-project/network/evm-server:latest --push


### PR DESCRIPTION
Using google artifact registry inplace of GCR for storing covalent docker public images