### PR TITLE
sets mixhash which is used as source of randomness post-merge

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -48,6 +48,7 @@ type stEnv struct {
 	Coinbase         libcommon.Address                      `json:"currentCoinbase"   gencodec:"required"`
 	Difficulty       *big.Int                               `json:"currentDifficulty"`
 	Random           *big.Int                               `json:"currentRandom"`
+	MixDigest        libcommon.Hash                         `json:"mixHash,omitempty"`
 	ParentDifficulty *big.Int                               `json:"parentDifficulty"`
 	GasLimit         uint64                                 `json:"currentGasLimit"   gencodec:"required"`
 	Number           uint64                                 `json:"currentNumber"     gencodec:"required"`
@@ -59,6 +60,7 @@ type stEnv struct {
 	ParentUncleHash  libcommon.Hash                         `json:"parentUncleHash"`
 	UncleHash        libcommon.Hash                         `json:"uncleHash,omitempty"`
 	Withdrawals      []*types.Withdrawal                    `json:"withdrawals,omitempty"`
+	WithdrawalsHash  *libcommon.Hash                        `json:"withdrawalsRoot,omitempty"`
 }
 
 type stEnvMarshaling struct {
@@ -93,7 +95,10 @@ func (stEnv *stEnv) loadFromReplica(replica *BlockReplica) {
 	}
 	stEnv.BaseFee = replica.Header.BaseFee.Int
 	stEnv.UncleHash = replica.Header.UncleHash
-	//stEnv.Random = replica  // TODO: will be added post merge
+	stEnv.WithdrawalsHash = replica.Header.WithdrawalsHash
+	//StEnv.Withdrawals = make([]*types.Withdrawal, len(replica.State.Withdrawals)) // this needs to be added
+	stEnv.Random = replica.Header.MixDigest.Big()
+	stEnv.MixDigest = replica.Header.MixDigest
 	//stEnv.ParentDifficulty = replica. // not needed if end.Difficulty is provided (and it IS provided)
 	//stEnv.ParentTimestamp // not needed if end.Difficulty is provided (and it IS provided)
 }

--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -112,7 +112,7 @@ var (
 			"\n\tSyntax <forkname>(+ExtraEip)",
 			strings.Join(tests.AvailableForks(), "\n\t    "),
 			strings.Join(vm.ActivateableEips(), ", ")),
-		Value: "ArrowGlacier",
+		Value: "Merge",
 	}
 	VerbosityFlag = cli.IntFlag{
 		Name:  "verbosity",

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ledgerwatch/erigon/common"
 	"github.com/ledgerwatch/erigon/common/math"
+	"github.com/ledgerwatch/erigon/core/types"
 )
 
 var _ = (*stEnvMarshaling)(nil)
@@ -30,6 +31,8 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 		Ommers           []ommer                                `json:"ommers,omitempty"`
 		BaseFee          *math.HexOrDecimal256                  `json:"currentBaseFee,omitempty"`
 		ParentUncleHash  libcommon.Hash                         `json:"parentUncleHash"`
+		UncleHash        libcommon.Hash                         `json:"uncleHash,omitempty"`
+		Withdrawals      []*types.Withdrawal                    `json:"withdrawals,omitempty"`
 	}
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
@@ -44,6 +47,8 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 	enc.Ommers = s.Ommers
 	enc.BaseFee = (*math.HexOrDecimal256)(s.BaseFee)
 	enc.ParentUncleHash = s.ParentUncleHash
+	enc.UncleHash = s.UncleHash
+	enc.Withdrawals = s.Withdrawals
 	return json.Marshal(&enc)
 }
 
@@ -62,6 +67,8 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 		Ommers           []ommer                                `json:"ommers,omitempty"`
 		BaseFee          *math.HexOrDecimal256                  `json:"currentBaseFee,omitempty"`
 		ParentUncleHash  *libcommon.Hash                        `json:"parentUncleHash"`
+		UncleHash        libcommon.Hash                         `json:"uncleHash,omitempty"`
+		Withdrawals      []*types.Withdrawal                    `json:"withdrawals,omitempty"`
 	}
 	var dec stEnv
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -107,5 +114,10 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	if dec.ParentUncleHash != nil {
 		s.ParentUncleHash = *dec.ParentUncleHash
 	}
+    s.UncleHash = dec.UncleHash
+	if dec.Withdrawals != nil {
+		s.Withdrawals = dec.Withdrawals
+	}
+
 	return nil
 }

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -311,18 +311,28 @@ func execute(ctx *cli.Context) error {
 		if prestate.Env.BaseFee == nil {
 			return NewError(ErrorVMConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}
-	}
-
-	// Sanity check, to not `panic` in state_transition
-	if prestate.Env.Random != nil && !eip1559 {
-		return NewError(ErrorVMConfig, errors.New("can only apply RANDOM on top of London chain rules"))
+	} else {
+		prestate.Env.Random = nil
 	}
 
 	if chainConfig.IsShanghai(prestate.Env.Timestamp) && prestate.Env.Withdrawals == nil {
 		return NewError(ErrorVMConfig, errors.New("shanghai config but missing 'withdrawals' in env section"))
 	}
 
-	if env := prestate.Env; env.Difficulty == nil {
+	isMerged := chainConfig.TerminalTotalDifficulty != nil && chainConfig.TerminalTotalDifficulty.BitLen() == 0
+	env := prestate.Env
+	if isMerged {
+		// post-merge:
+		// - random must be supplied
+		// - difficulty must be zero
+		switch {
+		case env.Random == nil:
+			return NewError(ErrorVMConfig, errors.New("post-merge requires currentRandom to be defined in env"))
+		case env.Difficulty != nil && env.Difficulty.BitLen() != 0:
+			return NewError(ErrorVMConfig, errors.New("post-merge difficulty must be zero (or omitted) in env"))
+		}
+		prestate.Env.Difficulty = nil
+	} else if env.Difficulty == nil {
 		// If difficulty was not provided by caller, we need to calculate it.
 		switch {
 		case env.ParentDifficulty == nil:
@@ -688,13 +698,16 @@ func dispatchOutput(ctx *cli.Context, baseDir string, result *core.EphemeralExec
 
 func NewHeader(env stEnv) *types.Header {
 	var header types.Header
-	header.UncleHash = env.UncleHash
 	header.Coinbase = env.Coinbase
 	header.Difficulty = env.Difficulty
-	header.Number = big.NewInt(int64(env.Number))
 	header.GasLimit = env.GasLimit
+	header.Number = big.NewInt(int64(env.Number))
 	header.Time = env.Timestamp
 	header.BaseFee = env.BaseFee
+	header.MixDigest = env.MixDigest
+
+	header.UncleHash = env.UncleHash
+	header.WithdrawalsHash = env.WithdrawalsHash
 
 	return &header
 }

--- a/cmd/evm/internal/t8ntool/types.go
+++ b/cmd/evm/internal/t8ntool/types.go
@@ -67,22 +67,23 @@ func (b *Bloom) SetBytes(d []byte) {
 }
 
 type Header struct {
-	ParentHash  common.Hash    `json:"parentHash"`
-	UncleHash   common.Hash    `json:"sha3Uncles"`
-	Coinbase    common.Address `json:"miner"`
-	Root        common.Hash    `json:"stateRoot"`
-	TxHash      common.Hash    `json:"transactionsRoot"`
-	ReceiptHash common.Hash    `json:"receiptsRoot"`
-	Bloom       Bloom          `json:"logsBloom"`
-	Difficulty  *BigInt        `json:"difficulty"`
-	Number      *BigInt        `json:"number"`
-	GasLimit    uint64         `json:"gasLimit"`
-	GasUsed     uint64         `json:"gasUsed"`
-	Time        uint64         `json:"timestamp"`
-	Extra       []byte         `json:"extraData"`
-	MixDigest   common.Hash    `json:"mixHash"`
-	Nonce       BlockNonce     `json:"nonce"`
-	BaseFee     *BigInt        `json:"baseFeePerGas"`
+	ParentHash      common.Hash    `json:"parentHash"`
+	UncleHash       common.Hash    `json:"sha3Uncles"`
+	Coinbase        common.Address `json:"miner"`
+	Root            common.Hash    `json:"stateRoot"`
+	TxHash          common.Hash    `json:"transactionsRoot"`
+	ReceiptHash     common.Hash    `json:"receiptsRoot"`
+	Bloom           Bloom          `json:"logsBloom"`
+	Difficulty      *BigInt        `json:"difficulty"`
+	Number          *BigInt        `json:"number"`
+	GasLimit        uint64         `json:"gasLimit"`
+	GasUsed         uint64         `json:"gasUsed"`
+	Time            uint64         `json:"timestamp"`
+	Extra           []byte         `json:"extraData"`
+	MixDigest       common.Hash    `json:"mixHash"`
+	Nonce           BlockNonce     `json:"nonce"`
+	BaseFee         *BigInt        `json:"baseFeePerGas"`
+	WithdrawalsHash *common.Hash   `json:"withdrawalsRoot" rlp:"nil,optional"`
 }
 
 type Transaction struct {


### PR DESCRIPTION
- this resolves the issue where the different blockhashs was being queried in evm tools run of a tx; this led to missing blockhashes error.