### PR TITLE
makes chainconfig pick the latest mainnet config

### DIFF
--- a/cmd/evm/internal/t8ntool/flags.go
+++ b/cmd/evm/internal/t8ntool/flags.go
@@ -112,7 +112,7 @@ var (
 			"\n\tSyntax <forkname>(+ExtraEip)",
 			strings.Join(tests.AvailableForks(), "\n\t    "),
 			strings.Join(vm.ActivateableEips(), ", ")),
-		Value: "Merge",
+		Value: "Shanghai",
 	}
 	VerbosityFlag = cli.IntFlag{
 		Name:  "verbosity",


### PR DESCRIPTION
- also the rules should be created using blockNumber and blockTimestamp against the config, so that older blocks can also be processed using the same latest config.