### PR TITLE
Rehash evm server healthcheck

### DIFF
--- a/Dockerfile-evm
+++ b/Dockerfile-evm
@@ -1,5 +1,5 @@
 # Build - first phase
-FROM golang:1.18-alpine as builder
+FROM golang:1.19-alpine as builder
 RUN mkdir /build
 WORKDIR /build
 RUN apk update && apk add --no-cache build-base linux-headers git bash ca-certificates libstdc++

--- a/Dockerfile-evm
+++ b/Dockerfile-evm
@@ -14,12 +14,11 @@ RUN apk update && apk add --no-cache bash=5.1.16-r0 libstdc++
 COPY --from=builder /build/build/bin/ /app
 SHELL ["/bin/bash", "-c"]
 RUN chmod +x ./evm
+
+HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3002/health
+
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 CMD [ "./evm t8n --server.mode --server.port 3002" ]
-
-#HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3002/health
-HEALTHCHECK --interval=10s --timeout=5s --start-period=2s \
-    CMD curl -f --retry 6 --max-time 5 --retry-delay 10 --retry-max-time 60 "http://localhost:3002/health" || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'
 
 # default
 EXPOSE 3002

--- a/Dockerfile-evm
+++ b/Dockerfile-evm
@@ -17,6 +17,9 @@ RUN chmod +x ./evm
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 CMD [ "./evm t8n --server.mode --server.port 3002" ]
 
-HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3002/health
+#HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3002/health
+HEALTHCHECK --interval=10s --timeout=5s --start-period=2s \
+    CMD curl -f --retry 6 --max-time 5 --retry-delay 10 --retry-max-time 60 "http://localhost:3002/health" || bash -c 'kill -s 15 -1 && (sleep 10; kill -s 9 -1)'
+
 # default
 EXPOSE 3002

--- a/Dockerfile-evm
+++ b/Dockerfile-evm
@@ -17,6 +17,6 @@ RUN chmod +x ./evm
 ENTRYPOINT [ "/bin/bash", "-l", "-c" ]
 CMD [ "./evm t8n --server.mode --server.port 3002" ]
 
-
+HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3002/health
 # default
 EXPOSE 3002

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -114,7 +114,7 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 	if dec.ParentUncleHash != nil {
 		s.ParentUncleHash = *dec.ParentUncleHash
 	}
-    s.UncleHash = dec.UncleHash
+	s.UncleHash = dec.UncleHash
 	if dec.Withdrawals != nil {
 		s.Withdrawals = dec.Withdrawals
 	}

--- a/cmd/evm/internal/t8ntool/server.go
+++ b/cmd/evm/internal/t8ntool/server.go
@@ -11,19 +11,39 @@ import (
 	"os"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/ledgerwatch/log/v3"
 
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	OK      = "OK"
+	BAD     = "BAD"
+	TIMEOUT = "TIMEOUT"
+)
+
 type EvmServer struct {
 	mux *http.ServeMux
 }
 
+type State struct {
+	status string
+}
+
+func NewState() *State {
+	return &State{status: OK}
+}
+
 func (eserv *EvmServer) StartServer(ctx *cli.Context, port int64) error {
+	httpState := NewState()
 	eserv.mux = http.NewServeMux()
 	eserv.mux.Handle("/process", eserv.recoveryWrapper(eserv.processHttpHandler(ctx)))
+	eserv.mux.Handle("/health", eserv.recoveryWrapper(eserv.healthHttpHandler(ctx, httpState)))
+	eserv.mux.Handle("/sabotage", eserv.recoveryWrapper(eserv.sabotageHttpHandler(ctx, httpState)))
+	eserv.mux.Handle("/recover", eserv.recoveryWrapper(eserv.recoverHttpHandler(ctx, httpState)))
+	eserv.mux.Handle("/timeout", eserv.recoveryWrapper(eserv.timeoutHttpHandler(ctx, httpState)))
 	log.Info("Listening", "port", port)
 	err := http.ListenAndServe(":"+strconv.Itoa(int(port)), eserv.mux)
 	if err != nil {
@@ -158,4 +178,50 @@ func (eserv *EvmServer) respondError(w http.ResponseWriter, err error) {
 	if err != nil {
 		log.Error("error writing data to connection", "error", err)
 	}
+}
+
+func (eserv *EvmServer) healthHttpHandler(ctx *cli.Context, s *State) http.Handler {
+	// Check the health of the server and return a status code accordingly
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		log.Info("Received /health request:", "source=", r.RemoteAddr, "status=", s.status)
+		switch s.status {
+		case OK:
+			io.WriteString(w, "I'm healthy")
+			return
+		case BAD:
+			http.Error(w, "Internal Error", 500)
+			return
+		case TIMEOUT:
+			time.Sleep(30 * time.Second)
+			return
+		default:
+			io.WriteString(w, "UNKNOWN")
+			return
+		}
+	}
+	return http.HandlerFunc(fn)
+}
+
+func (eserv *EvmServer) sabotageHttpHandler(ctx *cli.Context, s *State) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		s.status = BAD
+		io.WriteString(w, "Sabotage ON")
+	}
+	return http.HandlerFunc(fn)
+}
+
+func (eserv *EvmServer) recoverHttpHandler(ctx *cli.Context, s *State) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		s.status = OK
+		io.WriteString(w, "Recovered.")
+	}
+	return http.HandlerFunc(fn)
+}
+
+func (eserv *EvmServer) timeoutHttpHandler(ctx *cli.Context, s *State) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		s.status = TIMEOUT
+		io.WriteString(w, "Configured to timeout.")
+	}
+	return http.HandlerFunc(fn)
 }


### PR DESCRIPTION
* Rehash of #29  rebased off `covalent` branch


Implementing health checks for [ipfs-pinner]() and [evm-server](https://github.com/covalenthq/erigon/pull/29) such that if the container fails - willfarrell/autoheal picks it up and restarts the entire container, supported with [rudder](https://github.com/covalenthq/rudder/pull/120)

- Simulate a failure (sending a 500 http server error) with an endpoint available called `/sabotage`
```
root@cqt-bsp-finalizer:~# docker exec -it a1ec0cf1f131 /bin/bash
bash-5.1# wget -nv --spider localhost:3002/sabotage
Connecting to localhost:3002 (127.0.0.1:3002)
remote file exists
```
- Causes the `evm-server` to fail with /health status "BAD" leading to the restart 

```
May 02 00:11:46 cqt-bsp-finalizer docker[355825]: evm-server   | [INFO] [05-02|00:11:46.530] Received /health request:                source==127.0.0.1:57764 status==BAD
May 02 00:11:55 cqt-bsp-finalizer docker[355825]: autoheal     | 02-05-2023 00:11:55 Container /evm-server (a1ec0cf1f131) found to be unhealthy - Restarting container now with 10s timeout
May 02 00:11:56 cqt-bsp-finalizer docker[355825]: evm-server exited with code 0
May 02 00:11:56 cqt-bsp-finalizer docker[355825]: evm-server exited with code 0
May 02 00:11:56 cqt-bsp-finalizer docker[355825]: evm-server   | [INFO] [05-02|00:11:56.217] Listening                                port=3002
May 02 00:11:56 cqt-bsp-finalizer docker[355825]: rudder       | [info] synced to latest; waiting for 4263551 to be mined
May 02 00:12:06 cqt-bsp-finalizer docker[355825]: evm-server   | [INFO] [05-02|00:12:06.079] Received /health request:                source==127.0.0.1:52628 status==OK
```
- On running `docker ps` Up status should have a `healthy` / `unhealthy` next to it (if unhealthy will be restarted with auto heal)

```
26e649c3f9d0   us-docker.pkg.dev/covalent-project/network/rudder:latest        "/bin/bash -l -c '\n …"   2 minutes ago       Up About a minute                                                                                                                                    rudder
3b77b2f7be81   us-docker.pkg.dev/covalent-project/network/ipfs-pinner:latest   "/bin/bash -l -c './…"    2 minutes ago       Up About a minute (healthy)   0.0.0.0:3000->3000/tcp, :::3000->3000/tcp, 0/tcp, 5001/tcp, 8080-8081/tcp, 0.0.0.0:4001->4001/tcp, :::4001->4001/tcp   ipfs-pinner
a1ec0cf1f131   us-docker.pkg.dev/covalent-project/network/evm-server:latest    "/bin/bash -l -c './…"    About an hour ago   Up About a minute (healthy)   0/tcp, 0.0.0.0:3002->3002/tcp, :::3002->3002/tcp                                                                       evm-server
acc41018d09c   willfarrell/autoheal                                            "/docker-entrypoint …"    About an hour ago   Up About a minute (healthy)                                                                                                                          autoheal
```