### PR TITLE
removes RUN chmod to optimize evm-server docker layers

### DIFF
--- a/Dockerfile-evm
+++ b/Dockerfile-evm
@@ -11,9 +11,7 @@ FROM alpine:3.15.7
 RUN mkdir /app
 WORKDIR /app
 RUN apk update && apk add --no-cache bash=5.1.16-r0 libstdc++
-COPY --from=builder /build/build/bin/ /app
-SHELL ["/bin/bash", "-c"]
-RUN chmod +x ./evm
+COPY --from=builder --chmod=700 /build/build/bin/ /app
 
 HEALTHCHECK --interval=10s --timeout=5s CMD wget --no-verbose --tries=1 --spider localhost:3002/health
 


### PR DESCRIPTION
- https://blog.vamc19.dev/posts/dockerfile-copy-chmod/