### PR TITLE
Execute type 3 blob transactions using EBE in `evm-server` (Ethereum Migration v1.5)

### DIFF
--- a/cmd/evm/internal/t8ntool/README.md
+++ b/cmd/evm/internal/t8ntool/README.md
@@ -10,18 +10,23 @@ OG input can be provided by `--input.alloc`, `--input.env`, `--input.txs`
 Block specimen input is controlled by `--input.replica`. When this is provided, other input flags are ignored.
 
 Similary, the output is provided in two formats:
+
 - original: controlled by `output.alloc` (post-process allocations), `output.body` (rlp of transactions body)
+
 - block result: controlled by `--output.blockresult`
 
 each of the input or output value can be either `stdout`, some filename, or "" (for no output)
 
 example
+
 ```bash
  ./build/bin/evm t8n --input.replica replica.inp    --output.blockresult result_out --output.body "" --output.alloc "" --output.result ""
 ```
 
 ## server mode
+
 evm tool can be started as a http server:
+
 ```bash
 ➜ ./build/bin/evm t8n --server.mode                                                                                                         
 INFO[02-02|16:24:55.537] Listening                                port=3002
@@ -32,6 +37,7 @@ then you can make curl requests:
 ```bash
 ➜ curl -v -F filedata=@/Users/user/repos/rudder/test-data/block-specimen/15892740.specimen.json http://127.0.0.1:3002/process
 ```
+
 the input is a block specimen in json format.
 
 

--- a/cmd/evm/internal/t8ntool/gen_stenv.go
+++ b/cmd/evm/internal/t8ntool/gen_stenv.go
@@ -33,9 +33,9 @@ func (s stEnv) MarshalJSON() ([]byte, error) {
 		ParentUncleHash  libcommon.Hash                         `json:"parentUncleHash"`
 		UncleHash        libcommon.Hash                         `json:"uncleHash,omitempty"`
 		Withdrawals      []*types.Withdrawal                    `json:"withdrawals,omitempty"`
-		BlobGasUsed      *math.HexOrDecimal64                              `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *math.HexOrDecimal64                                `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *libcommon.Hash                       `json:"parentBeaconBlockRoot" rlp:"optional"`
+		BlobGasUsed      *math.HexOrDecimal64                   `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *math.HexOrDecimal64                   `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *libcommon.Hash                        `json:"parentBeaconBlockRoot" rlp:"optional"`
 	}
 	var enc stEnv
 	enc.Coinbase = common.UnprefixedAddress(s.Coinbase)
@@ -75,9 +75,9 @@ func (s *stEnv) UnmarshalJSON(input []byte) error {
 		ParentUncleHash  *libcommon.Hash                        `json:"parentUncleHash"`
 		UncleHash        libcommon.Hash                         `json:"uncleHash,omitempty"`
 		Withdrawals      []*types.Withdrawal                    `json:"withdrawals,omitempty"`
-		BlobGasUsed      *math.HexOrDecimal64                              `json:"blobGasUsed" rlp:"optional"`
-		ExcessBlobGas    *math.HexOrDecimal64                                `json:"excessBlobGas" rlp:"optional"`
-		ParentBeaconRoot *libcommon.Hash                       `json:"parentBeaconBlockRoot" rlp:"optional"`
+		BlobGasUsed      *math.HexOrDecimal64                   `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *math.HexOrDecimal64                   `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *libcommon.Hash                        `json:"parentBeaconBlockRoot" rlp:"optional"`
 	}
 	var dec stEnv
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -92,7 +92,7 @@ func ExecuteBlockEphemerally(
 	header := block.Header()
 
 	usedGas := new(uint64)
-	usedBlobGas := header.BlobGasUsed
+	usedBlobGas := new(uint64)
 	gp := new(GasPool)
 	gp.AddGas(block.GasLimit()).AddBlobGas(chainConfig.GetMaxBlobGasPerBlock())
 


### PR DESCRIPTION
* Re-execute for fields for type 3 txs ingested by `refiner` and generate receipts 
* Add support for casting all txs into respective block-result tx values 
* Enable full blobSideCars data to exist alongside block-results
* Add missing header fields  to exports 
* Fix adaptTx fn to ingest block-specimen data for missing fields 